### PR TITLE
Added in a check to ensure gateway is not None

### DIFF
--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -75,7 +75,7 @@ def index(request):
             options += "kernel_analysis=yes"
 
 
-        if gateway.lower() == "all":
+        if gateway and gateway.lower() == "all":
             for e in settings.GATEWAYS:
                 if ipaddy_re.match(settings.GATEWAYS[e]):
                     task_gateways.append(settings.GATEWAYS[e])


### PR DESCRIPTION
If gateways are not setup then gateway will be set to None by default on the POST request.  This checks to ensure gateway is not none before the string .lower() method is called on the None object.
